### PR TITLE
Vyplňování databáze testovacími daty - seeding

### DIFF
--- a/Bookong.Cli/Bookong.Cli.csproj
+++ b/Bookong.Cli/Bookong.Cli.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.10" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bookong.Infrastructure\Bookong.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bookong.Cli/Program.cs
+++ b/Bookong.Cli/Program.cs
@@ -1,0 +1,74 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+using Bookong.Infrastructure.Data;
+using Bookong.Infrastructure.Seeding;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+var root = new RootCommand("Bookong CLI tool");
+
+var demoOpt = new Option<bool>(name: "--demo", description: "Include demo data (authors, warehouses, books)", getDefaultValue: () => true);
+var resetOpt = new Option<bool>(name: "--reset", description: "Soft reset demo data before seeding", getDefaultValue: () => false);
+var connOpt = new Option<string?>(name: "--connection", description: "Connection string to the SQL Server database. If not provided, defaults to LocalDB.");
+
+var seedCmd = new Command("seed", "Run database seeders (lookups and optionally demo data)")
+{
+    demoOpt,
+    resetOpt,
+    connOpt
+};
+
+seedCmd.SetHandler(async (InvocationContext ctx) =>
+{
+    var demo = ctx.ParseResult.GetValueForOption(demoOpt);
+    var reset = ctx.ParseResult.GetValueForOption(resetOpt);
+    var connection = ctx.ParseResult.GetValueForOption(connOpt);
+
+    // Determine connection string
+    var connectionString = !string.IsNullOrWhiteSpace(connection)
+        ? connection
+        : Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
+          ?? "Server=(localdb)\\mssqllocaldb;Database=BookongDb;Trusted_Connection=True;";
+
+    // Build services
+    var services = new ServiceCollection();
+    services.AddLogging(b =>
+    {
+        b.AddConsole();
+        b.SetMinimumLevel(LogLevel.Information);
+    });
+    services.AddDbContext<BookongDbContext>(opt => opt.UseSqlServer(connectionString));
+    services.AddBookongSeeders();
+
+    await using var provider = services.BuildServiceProvider();
+    using var scope = provider.CreateScope();
+
+    var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("Seed");
+    var db = scope.ServiceProvider.GetRequiredService<BookongDbContext>();
+    var runner = scope.ServiceProvider.GetRequiredService<SeedRunner>();
+    var seeders = scope.ServiceProvider.GetServices<ISeeder>().ToArray();
+
+    logger.LogInformation("Migrating database...");
+    await db.Database.MigrateAsync(ctx.GetCancellationToken());
+
+    if (reset)
+    {
+        logger.LogWarning("Soft reset enabled: clearing demo-related tables...");
+        db.Books.RemoveRange(db.Books);
+        db.Authors.RemoveRange(db.Authors);
+        db.Warehouses.RemoveRange(db.Warehouses);
+        db.Addresses.RemoveRange(db.Addresses);
+        db.Publishers.RemoveRange(db.Publishers);
+        await db.SaveChangesAsync(ctx.GetCancellationToken());
+    }
+
+    logger.LogInformation("Running seeders. Include demo: {Demo}", demo);
+    await runner.RunAsync(db, seeders, demo, ctx.GetCancellationToken());
+
+    logger.LogInformation("Seeding complete.");
+});
+
+root.AddCommand(seedCmd);
+
+return await root.InvokeAsync(args);

--- a/Bookong.Infrastructure/Seeding/ISeeder.cs
+++ b/Bookong.Infrastructure/Seeding/ISeeder.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding;
+
+public interface ISeeder
+{
+    // Descriptive name for logs
+    string Name { get; }
+
+    // Ordering within the pipeline (lower runs first)
+    int Order { get; }
+
+    // True = only run when demo data is requested
+    bool IsDemoData { get; }
+
+    Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default);
+}

--- a/Bookong.Infrastructure/Seeding/SeedOptions.cs
+++ b/Bookong.Infrastructure/Seeding/SeedOptions.cs
@@ -1,0 +1,3 @@
+namespace Bookong.Infrastructure.Seeding;
+
+public record SeedOptions(bool DemoData, bool Reset);

--- a/Bookong.Infrastructure/Seeding/SeedRunner.cs
+++ b/Bookong.Infrastructure/Seeding/SeedRunner.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding;
+
+public class SeedRunner
+{
+    private readonly ILogger<SeedRunner> _logger;
+
+    public SeedRunner(ILogger<SeedRunner> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task RunAsync(BookongDbContext db, ISeeder[] seeders, bool includeDemoData, CancellationToken ct = default)
+    {
+        var ordered = seeders
+            .Where(s => includeDemoData || !s.IsDemoData)
+            .OrderBy(s => s.Order)
+            .ToArray();
+
+        foreach (var seeder in ordered)
+        {
+            try
+            {
+                _logger.LogInformation("Seeding {Seeder}...", seeder.Name);
+                await seeder.SeedAsync(db, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Seeder {Seeder} failed", seeder.Name);
+                throw;
+            }
+        }
+    }
+}

--- a/Bookong.Infrastructure/Seeding/SeedServiceCollectionExtensions.cs
+++ b/Bookong.Infrastructure/Seeding/SeedServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bookong.Infrastructure.Seeding;
+
+public static class SeedServiceCollectionExtensions
+{
+    public static IServiceCollection AddBookongSeeders(this IServiceCollection services)
+    {
+        // Seeders registration will be added here as they are created
+        services.AddSingleton<SeedRunner>();
+        services.AddSingleton<ISeeder, Seeders.Lookup.KindSeeder>();
+        services.AddSingleton<ISeeder, Seeders.Lookup.GenreSeeder>();
+        services.AddSingleton<ISeeder, Seeders.Lookup.PeriodSeeder>();
+        services.AddSingleton<ISeeder, Seeders.Demo.AuthorSeeder>();
+        services.AddSingleton<ISeeder, Seeders.Demo.PublisherSeeder>();
+        services.AddSingleton<ISeeder, Seeders.Demo.WarehouseSeeder>();
+        services.AddSingleton<ISeeder, Seeders.Demo.BookSeeder>();
+        return services;
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Demo/AuthorSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Demo/AuthorSeeder.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Demo;
+
+public class AuthorSeeder : ISeeder
+{
+    public string Name => "Demo Authors";
+    public int Order => 200;
+    public bool IsDemoData => true;
+
+    private static readonly (string FullName, int BirthYear)[] Authors = new[]
+    {
+        ("Karel Èapek", 1890),
+        ("Alois Jirásek", 1851),
+        ("Bohumil Hrabal", 1914),
+        ("Franz Kafka", 1883),
+        ("Milan Kundera", 1929),
+    };
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        foreach (var (full, birth) in Authors)
+        {
+            var parts = full.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var first = parts.First();
+            var last = parts.Length > 1 ? parts.Last() : string.Empty;
+            var middle = parts.Length > 2 ? string.Join(' ', parts.Skip(1).Take(parts.Length - 2)) : string.Empty;
+
+            if (!db.Authors.Any(a => a.FirstName == first && a.MiddleName == middle && a.LastName == last))
+            {
+                db.Authors.Add(new Author
+                {
+                    PublicId = Guid.NewGuid(),
+                    FirstName = first,
+                    MiddleName = middle,
+                    LastName = last,
+                    DateOfBirth = new DateTime(birth, 1, 1)
+                });
+            }
+        }
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Demo/BookSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Demo/BookSeeder.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Demo;
+
+public class BookSeeder : ISeeder
+{
+    public string Name => "Demo Books";
+    public int Order => 300;
+    public bool IsDemoData => true;
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        // Lookup helpers
+        async Task<Author> A(string full)
+        {
+            var parts = full.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var first = parts.First();
+            var last = parts.Length > 1 ? parts.Last() : string.Empty;
+            var middle = parts.Length > 2 ? string.Join(' ', parts.Skip(1).Take(parts.Length - 2)) : string.Empty;
+            return await db.Authors.FirstAsync(a => a.FirstName == first && a.MiddleName == middle && a.LastName == last, cancellationToken);
+        }
+        Task<Publisher?> P(string? name) => name is null
+            ? Task.FromResult<Publisher?>(null)
+            : db.Publishers.FirstOrDefaultAsync(p => p.Name == name, cancellationToken);
+        Task<Genre> G(string name) => db.Genres.FirstAsync(g => g.Name == name, cancellationToken);
+        Task<Kind> K(string name) => db.Kinds.FirstAsync(k => k.Name == name, cancellationToken);
+        Task<Period> Pe(string name) => db.Periods.FirstAsync(p => p.Name == name, cancellationToken);
+
+        static string MapKind(string input) => input switch
+        {
+            "Drama" => "Drama",
+            "Lyrika" => "Lyrika",
+            _ => "Epika"
+        };
+
+        async Task EnsureBook(string title, string author, string? publisher, string kind, string genre, ushort pages, string period, int year)
+        {
+            if (await db.Books.AnyAsync(b => b.Name == title, cancellationToken)) return;
+
+            var book = new Book
+            {
+                PublicId = Guid.NewGuid(),
+                Name = title,
+                Author = await A(author),
+                Publisher = await P(publisher),
+                Genre = await G(genre),
+                Kind = await K(MapKind(kind)),
+                Period = await Pe(period),
+                Pages = pages,
+                Borrowable = true,
+                DateRelease = new DateTime(year, 1, 1)
+            };
+            db.Books.Add(book);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        // Èapek
+        await EnsureBook("R.U.R.", "Karel Èapek", "Èeskoslovenský spisovatel", "Drama", "Drama", 96, "Èeská lit 20. a 21. st.", 1920);
+        await EnsureBook("Bílá nemoc", "Karel Èapek", "Èeskoslovenský spisovatel", "Drama", "Drama", 112, "Èeská lit 20. a 21. st.", 1937);
+        await EnsureBook("Matka", "Karel Èapek", "Èeskoslovenský spisovatel", "Drama", "Drama", 88, "Èeská lit 20. a 21. st.", 1938);
+        await EnsureBook("Krakatit", "Karel Èapek", "Odeon", "Epika", "Román", 256, "Èeská lit 20. a 21. st.", 1924);
+        await EnsureBook("Válka s mloky", "Karel Èapek", "Èeskoslovenský spisovatel", "Epika", "Román", 352, "Èeská lit 20. a 21. st.", 1936);
+
+        // Jirásek
+        await EnsureBook("F.L.Vìk", "Alois Jirásek", "Mladá fronta", "Epika", "Románová kronika", 648, "Sv. a èeská lit 19. st.", 1888);
+        await EnsureBook("Filozofská historie", "Alois Jirásek", "Mladá fronta", "Epika", "Historický román", 512, "Sv. a èeská lit 19. st.", 1878);
+        await EnsureBook("Temno", "Alois Jirásek", "Mladá fronta", "Epika", "Historický román", 432, "Sv. a èeská lit 19. st.", 1915);
+        await EnsureBook("Psohlavci", "Alois Jirásek", "Mladá fronta", "Epika", "Historický román", 384, "Sv. a èeská lit 19. st.", 1884);
+        await EnsureBook("Staré povìsti èeské", "Alois Jirásek", "Odeon", "Epika", "Soubor povìstí", 296, "Sv. a èeská lit 19. st.", 1894);
+
+        // Hrabal
+        await EnsureBook("Ostøe sledované vlaky", "Bohumil Hrabal", "Èeskoslovenský spisovatel", "Epika", "Novela", 96, "Èeská lit 20. a 21. st.", 1965);
+        await EnsureBook("Postøižiny", "Bohumil Hrabal", "Èeskoslovenský spisovatel", "Epika", "Povídka", 128, "Èeská lit 20. a 21. st.", 1976);
+        await EnsureBook("Obsluhoval jsem anglického krále", "Bohumil Hrabal", "Odeon", "Epika", "Román", 224, "Èeská lit 20. a 21. st.", 1983);
+        await EnsureBook("Taneèní hodiny pro starší a pokroèilé", "Bohumil Hrabal", "Èeskoslovenský spisovatel", "Epika", "Povídka", 144, "Èeská lit 20. a 21. st.", 1964);
+        await EnsureBook("Pøíliš hluèná samota", "Bohumil Hrabal", "Èeskoslovenský spisovatel", "Epika", "Novela", 104, "Èeská lit 20. a 21. st.", 1976);
+
+        // Kafka
+        await EnsureBook("Promìna", "Franz Kafka", "Odeon", "Epika", "Povídka", 72, "Sv. lit 20. a 21. st.", 1915);
+        await EnsureBook("Proces", "Franz Kafka", "Odeon", "Epika", "Román", 288, "Sv. lit 20. a 21. st.", 1925);
+        await EnsureBook("Zámek", "Franz Kafka", "Odeon", "Epika", "Román", 352, "Sv. lit 20. a 21. st.", 1926);
+        await EnsureBook("Amerika", "Franz Kafka", "Odeon", "Epika", "Román", 304, "Sv. lit 20. a 21. st.", 1927);
+        await EnsureBook("V kolonii pro zloèince", "Franz Kafka", "Odeon", "Epika", "Povídka", 48, "Sv. lit 20. a 21. st.", 1919);
+
+        // Kundera
+        await EnsureBook("Žert", "Milan Kundera", "Èeskoslovenský spisovatel", "Epika", "Román", 368, "Èeská lit 20. a 21. st.", 1967);
+        await EnsureBook("Nesnesitelná lehkost bytí", "Milan Kundera", "Odeon", "Epika", "Román", 320, "Èeská lit 20. a 21. st.", 1984);
+        await EnsureBook("Smìšné lásky", "Milan Kundera", "Èeskoslovenský spisovatel", "Epika", "Soubor povídek", 288, "Èeská lit 20. a 21. st.", 1963);
+        await EnsureBook("Kniha smíchu a zapomnìní", "Milan Kundera", "Odeon", "Epika", "Román", 272, "Èeská lit 20. a 21. st.", 1978);
+        await EnsureBook("Identity", "Milan Kundera", "Odeon", "Epika", "Novela", 168, "Èeská lit 20. a 21. st.", 1998);
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Demo/PublisherSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Demo/PublisherSeeder.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Demo;
+
+public class PublisherSeeder : ISeeder
+{
+    public string Name => "Demo Publishers";
+    public int Order => 205;
+    public bool IsDemoData => true;
+
+    private static readonly string[] Publishers =
+    {
+        "Èeskoslovenský spisovatel",
+        "Mladá fronta",
+        "Odeon"
+    };
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        foreach (var name in Publishers)
+        {
+            if (!db.Publishers.Any(p => p.Name == name))
+            {
+                db.Publishers.Add(new Publisher
+                {
+                    PublicId = Guid.NewGuid(),
+                    Name = name
+                });
+            }
+        }
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Demo/WarehouseSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Demo/WarehouseSeeder.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Demo;
+
+public class WarehouseSeeder : ISeeder
+{
+    public string Name => "Demo Warehouses";
+    public int Order => 210;
+    public bool IsDemoData => true;
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        var address = db.Addresses.FirstOrDefault(a => a.Street == "Hlavní" && a.City == "Trutnov");
+        if (address is null)
+        {
+            address = new Address
+            {
+                PublicId = Guid.NewGuid(),
+                Street = "Hlavní",
+                City = "Trutnov",
+                Number = "1",
+                ZipCode = "541 01"
+            };
+            db.Addresses.Add(address);
+            await db.SaveChangesAsync(cancellationToken);
+        }
+
+        if (!db.Warehouses.Any(w => w.Name == "Sklad A"))
+        {
+            db.Warehouses.Add(new Warehouse
+            {
+                PublicId = Guid.NewGuid(),
+                Name = "Sklad A",
+                Address = address
+            });
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Lookup/GenreSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Lookup/GenreSeeder.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Lookup;
+
+public class GenreSeeder : ISeeder
+{
+    public string Name => "Genres";
+    public int Order => 110;
+    public bool IsDemoData => false;
+
+    // Representative genres used in the dataset
+    private static readonly string[] Defaults = new[]
+    {
+        "Román", "Novela", "Povídka", "Románová kronika", "Historický román", "Soubor povídek", "Soubor povìstí", "Drama"
+    };
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        foreach (var name in Defaults)
+        {
+            if (!db.Genres.Any(k => k.Name == name))
+            {
+                db.Genres.Add(new Genre { PublicId = Guid.NewGuid(), Name = name });
+            }
+        }
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Lookup/KindSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Lookup/KindSeeder.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Lookup;
+
+public class KindSeeder : ISeeder
+{
+    public string Name => "Kinds";
+    public int Order => 100;
+    public bool IsDemoData => false;
+
+    // Only three kinds are used: Epika, Lyrika, Drama
+    private static readonly string[] Defaults = new[]
+    {
+        "Epika", "Lyrika", "Drama"
+    };
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        foreach (var name in Defaults)
+        {
+            if (!db.Kinds.Any(k => k.Name == name))
+            {
+                db.Kinds.Add(new Kind { PublicId = Guid.NewGuid(), Name = name });
+            }
+        }
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Bookong.Infrastructure/Seeding/Seeders/Lookup/PeriodSeeder.cs
+++ b/Bookong.Infrastructure/Seeding/Seeders/Lookup/PeriodSeeder.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Bookong.Domain.Entities;
+using Bookong.Infrastructure.Data;
+
+namespace Bookong.Infrastructure.Seeding.Seeders.Lookup;
+
+public class PeriodSeeder : ISeeder
+{
+    public string Name => "Periods";
+    public int Order => 120;
+    public bool IsDemoData => false;
+
+    private static readonly string[] Defaults = new[]
+    {
+        "Èeská lit 20. a 21. st.",
+        "Sv. a èeská lit 19. st.",
+        "Sv. lit 20. a 21. st."
+    };
+
+    public async Task SeedAsync(BookongDbContext db, CancellationToken cancellationToken = default)
+    {
+        foreach (var name in Defaults)
+        {
+            if (!db.Periods.Any(k => k.Name == name))
+            {
+                db.Periods.Add(new Period { PublicId = Guid.NewGuid(), Name = name });
+            }
+        }
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/docs/SEEDING.md
+++ b/docs/SEEDING.md
@@ -1,0 +1,30 @@
+# Seedování DB (CLI)
+
+Nástroj pro seedování databáze demo daty. Slouží pouze pro vývoj, data nejsou pravdivá.
+
+## Použití
+- Základní běh (včetně demo dat):
+  
+  dotnet run --project Bookong.Cli seed
+
+- Soft reset demo dat a znovu seed:
+  
+  dotnet run --project Bookong.Cli seed --reset
+
+- Bez demo dat:
+  
+  dotnet run --project Bookong.Cli seed --demo false
+
+- Vlastní připojení:
+  
+  dotnet run --project Bookong.Cli seed --connection "Server=.;Database=BookongDb;Trusted_Connection=True;TrustServerCertificate=True;"
+  
+  nebo nastav proměnnou:
+  
+  ConnectionStrings__DefaultConnection="Server=.;Database=BookongDb;Trusted_Connection=True;TrustServerCertificate=True;" dotnet run --project Bookong.Cli seed
+
+## Poznámky
+- Seeduje `Kinds (Epika, Lyrika, Drama)`, `Genres` (Román, Novela, Povídka, …), `Periods` (3 kategorie) a demo `Authors`, `Publishers`, `Books`.
+- Všechny knihy jsou `Borrowable = true`.
+- Soft reset maže tabulky: `Books`, `Authors`, `Warehouses`, `Addresses` a `Publishers`.
+- Idempotentní – existující záznamy se nevytvářejí dvakrát.


### PR DESCRIPTION
closes #10

Přidal jsem do solutionu nový projekt, Bookong.CLI.
Do Infrastructure jsem přidal kód pro seedování, z demo dat obsahuje cca 25 knih od 5 autorů a 3 nakladatelství a 1 sklad.
Přidá pak také potřebné druhy, žánry a období, které budou pravděpodobně velmi podobné produkčnímu nasazení.

Základní použití:
(Spouštějte v *Package Manager Console*)
`dotnet run --project Bookong.Cli seed --reset` - Vymaže celou databázi a vyplní vše
`dotnet run --project Bookong.Cli seed` - Začne rovnou vyplňovat, ale když bude v databázi něco se stejným jménem, položku přeskočí

Celá dokumentace je v docs/SEEDING.md.

Je to dělané hlavně jako pomocník pro vývoj, nepočítám s tím že by to někdo chtěl do budoucna udržovat, maximálně lehké změny

